### PR TITLE
added shared folders support under Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,12 +15,25 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |v, override| 
     config.vm.synced_folder ".", "/vagrant", mount_options: ["dmode=777"] # ensure any VM user can create files in subfolders - eg, /vagrant/tmp
     override.vm.network "private_network", ip: "192.168.50.4"
+
       #Enable NFS folder sharing if on Mac
       if RUBY_PLATFORM =~ /.*darwin.*/ 
         `mkdir -p workspace/environments`
         `mkdir -p workspace/src`
         override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", type: "nfs"
         override.vm.synced_folder "workspace/src", "/home/vagrant/src", type: "nfs"
+      end
+
+      #Enable folder sharing if on Windows
+      if RUBY_PLATFORM =~ /.*mswin|windows|mingw|cygwin.*/
+        "mkdir -p workspace/environments"
+        "mkdir -p workspace/src"
+
+        # enable symlinks http://stackoverflow.com/questions/24200333/symbolic-links-and-synced-folders-in-vagrant
+        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+
+        override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", mount_options: ["dmode=777"]
+        override.vm.synced_folder "workspace/src", "/home/vagrant/src", mount_options: ["dmode=777"]
       end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,4 @@
+require 'fileutils'
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.require_version ">= 1.6.5"
@@ -15,26 +16,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |v, override| 
     config.vm.synced_folder ".", "/vagrant", mount_options: ["dmode=777"] # ensure any VM user can create files in subfolders - eg, /vagrant/tmp
     override.vm.network "private_network", ip: "192.168.50.4"
+   
+    #Ensure workspace shares exist on host
+    FileUtils.mkdir_p('workspace/environments') unless File.exists?('workspace/environments')
+    FileUtils.mkdir_p('workspace/src') unless File.exists?('workspace/src')
+    #Enable NFS folder sharing if on Mac
+    if RUBY_PLATFORM =~ /.*darwin.*/ 
+      override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", type: "nfs"
+      override.vm.synced_folder "workspace/src", "/home/vagrant/src", type: "nfs"
+    end
+    #Enable folder sharing if on Windows
+    if RUBY_PLATFORM =~ /.*mswin|windows|mingw|cygwin.*/
+      # enable symlinks http://stackoverflow.com/questions/24200333/symbolic-links-and-synced-folders-in-vagrant
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+      override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", mount_options: ["dmode=777"]
+      override.vm.synced_folder "workspace/src", "/home/vagrant/src", mount_options: ["dmode=777"]
+    end
 
-      #Enable NFS folder sharing if on Mac
-      if RUBY_PLATFORM =~ /.*darwin.*/ 
-        `mkdir -p workspace/environments`
-        `mkdir -p workspace/src`
-        override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", type: "nfs"
-        override.vm.synced_folder "workspace/src", "/home/vagrant/src", type: "nfs"
-      end
-
-      #Enable folder sharing if on Windows
-      if RUBY_PLATFORM =~ /.*mswin|windows|mingw|cygwin.*/
-        "mkdir -p workspace/environments"
-        "mkdir -p workspace/src"
-
-        # enable symlinks http://stackoverflow.com/questions/24200333/symbolic-links-and-synced-folders-in-vagrant
-        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
-
-        override.vm.synced_folder "workspace/environments", "/home/vagrant/environments", mount_options: ["dmode=777"]
-        override.vm.synced_folder "workspace/src", "/home/vagrant/src", mount_options: ["dmode=777"]
-      end
   end
 
   config.vm.provision "shell", run: "always", inline: <<EOF 

--- a/_setup/runtime/install_dependancies
+++ b/_setup/runtime/install_dependancies
@@ -145,6 +145,22 @@ fi
 echo "jekyll: $(jekyll -version)" | head -n 1
 
 #
+# system: logstash
+#
+LOGSTASH_VERSION="1.4.0"
+if [ ! -f /var/local/logstash-$LOGSTASH_VERSION/bin/logstash ]; then
+  echo "Installing logstash-$LOGSTASH_VERSION ..."
+
+  curl -L "https://download.elasticsearch.org/logstash/logstash/logstash-$LOGSTASH_VERSION.tar.gz" | tar -xzf- -C /var/local
+  echo "Installing Logstash community plugins.  This takes a few minutes..."
+  (
+    cd /var/local/logstash-$LOGSTASH_VERSION
+    bin/plugin install contrib
+  )
+fi
+echo "logstash: v$LOGSTASH_VERSION"
+
+#
 # util: vim
 #
 if ! (which vim 1>/dev/null 2>&1) ; then


### PR DESCRIPTION
This adds functionality for Windows hosts to expose 

* `[logsearch workspace] ~/environments ` --> HOST:  `workspace/environments` 
* `[logsearch workspace] ~/src`  --> HOST: `workspace/src`

so they can be edited by the user's favourite text editor on the host.

It requires that vagrant is started from an Administrator command prompt