### PR TITLE
Upgrade workspace VM to include logsearch-v18

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   #Ubuntu 14.04 VM with BOSH lite installed (used to create a new logsearch-workspace box from scratch via 'vagrant package')
   #config.vm.box = 'cloudfoundry/bosh-lite'
-  #config.vm.box_version = '388'
+  #config.vm.box_version = '2811'
   #Provisioned LogSearch workspace (created from 'cloudfoundry/bosh-lite' via 'vagrant package', see above)
-  config.vm.box = 'logsearch-workspace-201501270921Z'
-  config.vm.box_url = 'https://s3-eu-west-1.amazonaws.com/ci-logsearch/vagrant/boxes/logsearch-workspace-201501270921Z.box'
+  config.vm.box = 'logsearch-workspace-201502251520Z.box'
+  config.vm.box_url = 'https://s3-eu-west-1.amazonaws.com/ci-logsearch/vagrant/boxes/logsearch-workspace-201502251520Z.box'
   config.vm.hostname = 'logsearch-workspace'
 
   config.vm.provider :virtualbox do |v, override| 

--- a/_setup/runtime/add_new_workspace
+++ b/_setup/runtime/add_new_workspace
@@ -65,6 +65,7 @@ end
 `echo 'Port Mappings:' > #{options[:home_dir]}/port_mappings.txt`
 expose_container options[:local_ip], "#{10+options[:tenant_number]}080",  "10.244.#{10+options[:tenant_number]}.2", 80, options
 expose_container options[:local_ip], "#{10+options[:tenant_number]}443", "10.244.#{10+options[:tenant_number]}.6", 443, options
+expose_container options[:local_ip], "#{10+options[:tenant_number]}081", "10.244.#{10+options[:tenant_number]}.14", 80, options
 
 `echo 'export LOCAL_IP="#{options[:local_ip]}"' >> #{options[:home_dir]}/.bash_profile`
 `echo 'export TENANT_NUMBER=#{options[:tenant_number]}' >> #{options[:home_dir]}/.bash_profile`

--- a/_setup/runtime/workspace_skel/environments/local/test/logsearch/manifest.yml
+++ b/_setup/runtime/workspace_skel/environments/local/test/logsearch/manifest.yml
@@ -29,19 +29,27 @@ update:
 resource_pools:
 - name: warden
   network: warden
-  size: 6
+  size: 7
   stemcell:
     name: bosh-warden-boshlite-ubuntu-trusty-go_agent
     version: latest
   cloud_properties: {}
 
 jobs:
+- name: kibana
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: warden
+    static_ips:
+    - 10.244.<%=ip_block%>.14
+  templates:
+  - { name: kibana, release: logsearch }
 - name: api
   release: logsearch
   templates: 
   - name: elasticsearch
   - name: api
-  - name: collectd
   update:
     serial: true
   instances: 1
@@ -51,9 +59,6 @@ jobs:
     static_ips:
     - 10.244.<%=ip_block%>.2
   properties:
-    collectd:
-      python_elasticsearch:
-        enabled: true
     elasticsearch:
       node:
         allow_data: false
@@ -69,7 +74,6 @@ jobs:
 - name: ingestor
   release: logsearch
   templates:
-  - name: collectd
   - name: ingestor_syslog
   instances: 1
   resource_pool: warden
@@ -81,7 +85,6 @@ jobs:
 - name: queue
   release: logsearch
   templates:
-  - name: collectd
   - name: queue
   instances: 1
   resource_pool: warden
@@ -89,15 +92,10 @@ jobs:
   - name: warden
     static_ips:
     - 10.244.<%=ip_block%>.10
-  properties:
-    collectd:
-      python_redis:
-        enabled: true
 
 - name: log_parser
   release: logsearch
   templates:
-  - name: collectd
   - name: log_parser
   instances: 1
   resource_pool: warden
@@ -108,7 +106,6 @@ jobs:
   release: logsearch
   templates:
   - name: elasticsearch
-  - name: collectd
   update:
     serial: true
   instances: 1
@@ -117,9 +114,6 @@ jobs:
   - name: warden
   persistent_disk: 1024
   properties:
-    collectd:
-      python_elasticsearch:
-        enabled: true
     elasticsearch:
       node:
         allow_master: false
@@ -128,7 +122,6 @@ jobs:
   release: logsearch
   templates:
   - name: elasticsearch
-  - name: collectd
   update:
     serial: true
   instances: 1
@@ -137,14 +130,14 @@ jobs:
   - name: warden
   persistent_disk: 1024
   properties:
-    collectd:
-      python_elasticsearch:
-        enabled: true
     elasticsearch:
       node:
         allow_master: false
 
 properties: 
+  kibana:
+    elasticsearch: http://127.0.0.1:9200
+    port: 80 
   elasticsearch:
     host: 10.244.<%=ip_block%>.2
     cluster_name: <%= deployment_name %>


### PR DESCRIPTION
Update the bundled release of logsearch to v18 in the base workspace VM image.

Also updates the bundled `local/test/logsearch/manifest.yml` to expose Kibana4.

Includes updates of related components:

* bosh-lite 2811, 
* stemcell: bosh-warden-boshlite-ubuntu-trusty-go_agent v2776